### PR TITLE
Feature: AIDEVS-8 - Mensaje inicial para nuevo hilo en mcp review assigns

### DIFF
--- a/src/review_assign/README.md
+++ b/src/review_assign/README.md
@@ -15,6 +15,7 @@ Este es un servidor de Protocolo de Control de Máquina (MCP) para la asignació
 - Notificaciones a Google Chat a través de webhooks (opcional)
 - Configuración personalizable de equipos y repositorios
 - Detección automática de miembros de equipos desde GitHub
+- Mensajes iniciales en Google Chat (opcional) para abrir hilos de revisión de PRs
 - Exclusión manual de miembros del equipo para revisiones
 
 ## Configuración
@@ -207,6 +208,13 @@ Para excluir miembros, añade el parámetro `exclude_members_by_nickname` a tu c
     - `thread_key`: (Opcional) Clave para agrupar mensajes en Google Chat (default: "review-pr-NUM")
     - `exclude_nickname`: (Opcional) Nickname de GitHub a excluir solo para esta asignación
 
+- `open_review_thread`: Publica un mensaje en un hilo de Google Chat
+  - Parámetros:
+    - `team`: (Opcional) Nombre del equipo configurado (TeamConfig.team_name). Si se especifica, tiene prioridad para resolver el webhook.
+    - `repo`: (Opcional) Repositorio en formato owner/repo (fallback para resolver el equipo correspondiente si no se especifica `team`).
+    - `thread_key`: Clave para agrupar mensajes en Google Chat
+    - `text`: Texto del mensaje a publicar
+
 - `list_teams`: Lista los equipos configurados y sus miembros
 
 ## Ejemplos de uso
@@ -274,6 +282,44 @@ Asigna un revisor al PR #123 del repositorio bukhr/k8s en el hilo con clave `lla
 ```
 
 Respuesta:
+
+```json
+{
+  "status": "success",
+  "message": "Revisor asignado exitosamente: Nombre Completo (usuario)",
+  "pr": {
+    "number": 123,
+    "title": "Título del PR",
+    "url": "https://github.com/bukhr/k8s/pull/123",
+    "author": "autor-pr"
+  },
+  "reviewer": {
+    "name": "Nombre Completo",
+    "github": "usuario",
+    "email": "usuario@ejemplo.com"
+  },
+  "team": "Equipo Ejemplo",
+  "thread_key": "llave-del-hilo"
+}
+```
+
+#### Abrir hilo con un mensaje inicial y asignar un revisor
+
+```text
+Asigna un revisor al PR #123 del repositorio bukhr/k8s en el hilo con clave `llave-del-hilo` con la mensaje inicial "Hola team, estoy abriendo este hilo para la revisión de los PRs del tema Ejemplo"
+```
+
+Respuesta (open_review_thread):
+
+```json
+{
+  "status": "success",
+  "thread_key": "llave-del-hilo",
+  "repo": null
+}
+```
+
+Respuesta (assign_reviewer):
 
 ```json
 {

--- a/src/review_assign/main.ts
+++ b/src/review_assign/main.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAssignReviewerTool } from './tools/assign-reviewer.js';
 import { registerListTeamsTool } from './tools/list-teams.js';
+import { registerOpenReviewThreadTool } from './tools/open-review-thread.js';
 import { appLogger } from './utils/logger.js';
 
 /**
@@ -20,6 +21,7 @@ const server = new McpServer({
 
 registerAssignReviewerTool(server);
 registerListTeamsTool(server);
+registerOpenReviewThreadTool(server);
 
 const transport = new StdioServerTransport();
 server.connect(transport);

--- a/src/review_assign/tests/services/notification.test.ts
+++ b/src/review_assign/tests/services/notification.test.ts
@@ -33,7 +33,7 @@ describe('notification service', () => {
         jest.clearAllMocks();
     });    
 
-    test('sendChatNotification should send notification', async () => {
+    test('sendChatNotification should send assignment notification', async () => {
         mockFetch({ data: 'test' });
 
         const webhookUrl = 'test';
@@ -65,8 +65,8 @@ describe('notification service', () => {
             prUrl,
             threadKey
         );
-        expect(global.fetch).toHaveBeenCalled();
-        expect(mockInfoLogger).toHaveBeenCalledWith('Notificación enviada exitosamente', {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockInfoLogger).toHaveBeenCalledWith('Mensaje enviada exitosamente', {
             message: JSON.stringify(message)
         });
     });
@@ -87,7 +87,7 @@ describe('notification service', () => {
         expect(mockWarnLogger).toHaveBeenCalledWith('No se envió notificación: webhook_url no configurado');
     });
 
-    test('sendChatNotification should throw error', async () => {
+    test('sendChatNotification should log error on HTTP failure', async () => {
         mockFetch({ data: 'test' }, false, 500);
 
         await notificationService.sendChatNotification(
@@ -100,10 +100,10 @@ describe('notification service', () => {
             'test'
         );
         expect(global.fetch).toHaveBeenCalled();
-        expect(mockErrorLogger).toHaveBeenCalledWith('Error al enviar notificación', {
-            error: 'Error HTTP: 500',
+        expect(mockErrorLogger).toHaveBeenCalledWith('Error al enviar notificación', expect.objectContaining({
+            error: expect.stringContaining('Error HTTP al enviar mensaje: 500'),
             repo: 'test',
             pr: 'test'
-        });
+        }));
     });
 });

--- a/src/review_assign/tests/tools/open-review-thread.test.ts
+++ b/src/review_assign/tests/tools/open-review-thread.test.ts
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+type ToolHandler = (params: any) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+const mockLoadConfiguration = jest.fn().mockReturnValue({ teams: [] });
+jest.unstable_mockModule('../../config/settings.js', () => ({
+  loadConfiguration: mockLoadConfiguration
+}));
+
+const mockGetTeamMembers = jest.fn<() => Promise<any[]>>().mockResolvedValue([]);
+const mockIsTeamRepository = jest.fn().mockReturnValue(true);
+jest.unstable_mockModule('../../services/team.js', () => ({
+  getMembers: mockGetTeamMembers,
+  isTeamRepository: mockIsTeamRepository
+}));
+
+const mockPostChatMessage = jest.fn();
+jest.unstable_mockModule('../../services/notification.js', () => ({
+  postChatMessage: mockPostChatMessage
+}));
+
+const mockLoggerInfo = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockLoggerError = jest.fn();
+jest.unstable_mockModule('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError
+  })
+}));
+
+let toolModule: typeof import('../../tools/open-review-thread.js');
+let mockServer: McpServer;
+
+beforeAll(async () => {
+  toolModule = await import('../../tools/open-review-thread.js');
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockServer = { tool: jest.fn() } as unknown as McpServer;
+});
+
+describe('open-review-thread tool', () => {
+  test('registers tool', () => {
+    toolModule.registerOpenReviewThreadTool(mockServer);
+    expect(mockServer.tool).toHaveBeenCalledTimes(1);
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'open_review_thread',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  test('publishes with team', async () => {
+    toolModule.registerOpenReviewThreadTool(mockServer);
+    const handlerFn = (mockServer.tool as jest.Mock).mock.calls[0][3] as ToolHandler;
+
+    mockGetTeamMembers.mockResolvedValue([
+      { team_name: 'DevOps', webhook_url: 'https://webhook', members: [], repositories: [] }
+    ]);
+
+    const res = await handlerFn({ team: 'DevOps', thread_key: 'k', text: 'hola' });
+
+    expect(mockPostChatMessage).toHaveBeenCalledWith('https://webhook', 'k', 'hola');
+    expect(JSON.parse(res.content[0].text)).toEqual(expect.objectContaining({ status: 'success', team: 'DevOps' }));
+  });
+
+  test('publishes with repo fallback', async () => {
+    toolModule.registerOpenReviewThreadTool(mockServer);
+    const handlerFn = (mockServer.tool as jest.Mock).mock.calls[0][3] as ToolHandler;
+
+    mockIsTeamRepository.mockReturnValue(true);
+    mockGetTeamMembers.mockResolvedValue([
+      { team_name: 'DevOps', webhook_url: 'https://webhook', members: [], repositories: ['owner/repo'] }
+    ]);
+
+    const res = await handlerFn({ repo: 'owner/repo', thread_key: 'k', text: 'hola' });
+
+    expect(mockPostChatMessage).toHaveBeenCalledWith('https://webhook', 'k', 'hola');
+    expect(JSON.parse(res.content[0].text)).toEqual(expect.objectContaining({ status: 'success', repo: 'owner/repo' }));
+  });
+
+  test('errors when neither team nor repo provided', async () => {
+    toolModule.registerOpenReviewThreadTool(mockServer);
+    const handlerFn = (mockServer.tool as jest.Mock).mock.calls[0][3] as ToolHandler;
+
+    const res = await handlerFn({ thread_key: 'k', text: 'hola' });
+
+    expect(mockPostChatMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain('Error: Debe proporcionar');
+  });
+
+  test('errors when webhook not found', async () => {
+    toolModule.registerOpenReviewThreadTool(mockServer);
+    const handlerFn = (mockServer.tool as jest.Mock).mock.calls[0][3] as ToolHandler;
+
+    mockGetTeamMembers.mockResolvedValue([{ team_name: 'DevOps', members: [], repositories: [] }]);
+
+    const res = await handlerFn({ team: 'DevOps', thread_key: 'k', text: 'hola' });
+
+    expect(mockPostChatMessage).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain('Error: No se encontró webhook_url');
+  });
+});

--- a/src/review_assign/tools/open-review-thread.ts
+++ b/src/review_assign/tools/open-review-thread.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { loadConfiguration } from '../config/settings.js';
+import { postChatMessage } from '../services/notification.js';
+import { createLogger } from '../utils/logger.js';
+import { TeamConfig } from '../types/index.js';
+import { getMembers, isTeamRepository } from '../services/team.js';
+import { GithubTeamProvider } from '../providers/github-team-provider.js';
+
+const openThreadLogger = createLogger('review_assign_tool', 'open-review-thread');
+
+/**
+ * Publica un mensaje en un hilo de Google Chat
+ * @param team Nombre del equipo configurado para resolver el webhook
+ * @param repo Repositorio en formato owner/repo (fallback para resolver el equipo)
+ * @param thread_key Clave del hilo
+ * @param text Texto del mensaje a publicar
+ */
+export const registerOpenReviewThreadTool = (server: McpServer) => {
+  server.tool(
+    'open_review_thread',
+    'Publica un mensaje inicial en un hilo de Google Chat',
+    {
+      team: z.string().optional().describe('Nombre del equipo configurado (TeamConfig.team_name)'),
+      repo: z.string().optional().describe('Repositorio en formato owner/repo (fallback para resolver el equipo)'),
+      thread_key: z.string().describe('Clave para agrupar mensajes en Google Chat'),
+      text: z.string().describe('Texto del mensaje a publicar en el hilo')
+    },
+    async ({ team, repo, thread_key, text }) => {
+      try {
+        const config = loadConfiguration();
+
+        if (!team && !repo) {
+          openThreadLogger.warn('Debe proporcionar "team" o "repo" para resolver el webhook');
+          return {
+            content: [{ type: 'text', text: 'Error: Debe proporcionar "team" o "repo".' }]
+          };
+        }
+
+        const githubTeamProvider = new GithubTeamProvider();
+        const teams = await getMembers(config, githubTeamProvider);
+
+        let matchingTeam: TeamConfig | undefined;
+        if (team) {
+          matchingTeam = teams.find((t: TeamConfig) => t.team_name.toLowerCase() === team!.toLowerCase());
+        } else if (repo) {
+          matchingTeam = teams.find((t: TeamConfig) => isTeamRepository(t, repo!));
+        }
+        const webhookUrl: string | undefined = matchingTeam?.webhook_url;
+
+        if (!webhookUrl) {
+          openThreadLogger.warn('No se encontró webhook_url para enviar el mensaje inicial', { team: team ?? matchingTeam?.team_name, repo });
+          return {
+            content: [{ type: 'text', text: 'Error: No se encontró webhook_url para enviar el mensaje.' }]
+          };
+        }
+
+        await postChatMessage(webhookUrl, thread_key, text);
+
+        openThreadLogger.info('Mensaje inicial publicado correctamente', { team: team ?? matchingTeam?.team_name, repo, thread_key });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ status: 'success', thread_key, team: team ?? matchingTeam?.team_name, repo: repo ?? null }) }]
+        };
+      } catch (error) {
+        openThreadLogger.error('Error en open_review_thread', {
+          error: error instanceof Error ? error.message : String(error),
+          team,
+          repo,
+          thread_key
+        });
+        return {
+          content: [{ type: 'text', text: `Error al publicar mensaje inicial: ${error}` }]
+        };
+      }
+    }
+  );
+};


### PR DESCRIPTION
[AIDEVS-8](https://buk.atlassian.net/browse/AIDEVS-8)

## Description

## Server Details
- Server: Review Assigns
- Changes to: tools, resources

## Motivation and Context
Permitir que se envié una mensaje inicial al crear un nuevo hilo en Google Chat para dar contexto al equipo de que se trata el hilo.

## How Has This Been Tested?
- Pruebas Unitarias
- Ejecución local

## Breaking Changes
No hay.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

Fue creado un nuevo tool para permitir que su uso sea opcional. Cuando intenté implementar dentro del tool `assign_reviewer` como parámetro opcional, el client (la IA) intentaba agregar siempre un mensaje adicional, para que no hiciera tenía que decir para no hacer, lo que no era la idea. Por eso se creó un tool por separado, de esa forma la IA solo va a agregar un mensaje inicial al hilo si es explícitamente requerido por el usuario.