### PR TITLE
feat: considerar reviews pendientes

### DIFF
--- a/src/review_assign/services/reviewer.ts
+++ b/src/review_assign/services/reviewer.ts
@@ -1,6 +1,6 @@
 import { TeamMember } from '../types/index.js';
-import { searchReviewedPRs } from './github.js';
-import { ReviewerSelection, ReviewerStats, ReviewedPR } from '../types/index.js';
+import { searchReviewedPRs, searchPendingReviewPRs } from './github.js';
+import { ReviewerSelection, ReviewerStats, ReviewedPR, PendingReviewPR } from '../types/index.js';
 
 /**
  * Cuenta el número de revisiones realizadas por un miembro en los últimos días
@@ -33,6 +33,34 @@ export const countMemberReviews = async (
 }
 
 /**
+ * Cuenta el número de revisiones pendientes asignadas a un miembro
+ * @param member Miembro del equipo
+ * @param teamRepositories Repositorios del equipo
+ * @returns Número de revisiones pendientes asignadas al miembro
+ */
+export const countMemberPendingReviews = async (
+    member: TeamMember,
+    teamRepositories: string[]
+): Promise<number> => {
+    try {
+        const pendingReviews: PendingReviewPR[] = await searchPendingReviewPRs(member.nickname_github);
+        let teamPendingReviews = 0;
+
+        for (const review of pendingReviews) {
+            const repoName = review.repository.nameWithOwner;
+            if (teamRepositories.includes(repoName)) {
+                teamPendingReviews++;
+            }
+        }
+
+        return teamPendingReviews;
+    } catch (error) {
+        console.error(`Error al contar revisiones pendientes para ${member.nickname_github}: ${error}`);
+        return 0;
+    }
+}
+
+/**
  * Selecciona el revisor óptimo para un PR
  * @param availableMembers Miembros disponibles para revisar
  * @param teamRepositories Repositorios del equipo
@@ -47,13 +75,19 @@ export const selectOptimalReviewer = async (
     const reviewStats: ReviewerStats[] = [];
     
     for (const member of availableMembers) {
-        const count: number = await countMemberReviews(member, teamRepositories, days);
+        const completedCount: number = await countMemberReviews(member, teamRepositories, days);
+        const pendingCount: number = await countMemberPendingReviews(member, teamRepositories);
         const workloadFactor = member.workloadFactor ?? 1.0;
-        const normalizedCount = count / workloadFactor;
-        
+
+        // Consideramos tanto las revisiones completadas como las pendientes en la carga de trabajo
+        // Las pendientes tienen un peso mayor ya que son trabajo actual que debe realizarse
+        const weightedCount = completedCount + (pendingCount * 2); // Las pendientes pesan el doble
+        const normalizedCount = weightedCount / workloadFactor;
+
         reviewStats.push({
             member,
-            reviewCount: count,
+            reviewCount: completedCount,
+            pendingReviewCount: pendingCount,
             normalizedCount: normalizedCount
         });
     }

--- a/src/review_assign/tools/assign-reviewer.ts
+++ b/src/review_assign/tools/assign-reviewer.ts
@@ -110,7 +110,9 @@ export const registerAssignReviewerTool = (server: McpServer) => {
                     name: stat.member.name,
                     github: stat.member.nickname_github,
                     email: stat.member.email,
-                    reviews_count: stat.normalizedCount
+                    completed_reviews: stat.reviewCount,
+                    pending_reviews: stat.pendingReviewCount,
+                    weighted_score: stat.normalizedCount
                 }));
                 
                 return {
@@ -133,7 +135,8 @@ export const registerAssignReviewerTool = (server: McpServer) => {
                             team: matchingTeam.team_name,
                             thread_key: actualThreadKey,
                             selection_criteria: {
-                                method: "Menor carga de trabajo en los últimos " + days + " días",
+                                method: "Menor carga de trabajo considerando revisiones completadas en los últimos " + days + " días y revisiones pendientes",
+                                weighting: "Las revisiones pendientes tienen un peso doble en el cálculo de carga",
                                 available_reviewers: reviewersInfo
                             }
                         }, null, 2) 

--- a/src/review_assign/types/index.ts
+++ b/src/review_assign/types/index.ts
@@ -35,6 +35,7 @@ export interface LogConfig {
 export interface ReviewerStats {
     member: TeamMember;
     reviewCount: number;
+    pendingReviewCount: number;
     normalizedCount: number;
 }
 
@@ -53,4 +54,18 @@ export interface ReviewedPR {
     repository: { name: string, nameWithOwner: string };
     url: string;
     title: string;
+}
+
+export interface PendingReviewPR {
+    number: number;
+    repository: { name: string, nameWithOwner: string };
+    url: string;
+    title: string;
+    requestedReviewers?: { login: string }[];
+}
+
+export interface LastReviewer {
+    repository: string;
+    nickname_github: string;
+    assignedAt: number;
 }


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details

- Server: review_assign
- Changes to: tools, resources

## Motivation and Context

El estado actual del MCP no consideran los PRs esperando revisión, por lo que asigna a la misma persona hasta que esta complete sus revisiones asignadas, recién ahí se cuentan dentro de su carga

## How Has This Been Tested?

Se probó la asignación de PRs a través de Cascade, asignando dos PRs y obteniendo diferentes revisores

## Breaking Changes

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
