### PR TITLE
feat: permitir obtener los archivos adjuntos de un ticket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1494,6 +1494,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -6061,6 +6071,12 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6372,6 +6388,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
       }
     },
     "node_modules/picocolors": {
@@ -8930,10 +8962,12 @@
         "@modelcontextprotocol/sdk": "^1.9.0",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
+        "pdf-parse": "^1.1.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
         "@types/node": "^22.14.1",
+        "@types/pdf-parse": "^1.1.4",
         "typescript": "^5.8.3"
       }
     }

--- a/src/zendesk/README.md
+++ b/src/zendesk/README.md
@@ -1,6 +1,6 @@
 # Servidor MCP para Zendesk
 
-Un servidor Model Context Protocol (MCP) que se integra con la API de Zendesk, permitiendo la integración con Windsurf y otros clientes compatibles con MCP.
+Un servidor Model Context Protocol (MCP) que se integra con la API de Zendesk, permitiendo la integración con Claude Code y otros clientes compatibles con MCP.
 
 ## Características
 
@@ -8,6 +8,8 @@ Un servidor Model Context Protocol (MCP) que se integra con la API de Zendesk, p
 - **Detalles de Artículos**: Obtiene información detallada de artículos específicos por ID
 - **Consulta de Tickets**: Obtiene detalles de tickets específicos de Zendesk por ID
 - **Comentarios de Tickets**: Recupera todos los comentarios para un ticket específico de Zendesk
+- **Adjuntos de Tickets**: Lista todos los adjuntos de los comentarios de un ticket con sus metadatos
+- **Lectura de Adjuntos**: Descarga y procesa adjuntos; las imágenes se retornan como bloques visuales que Claude puede interpretar directamente
 
 ## Arquitectura del Proyecto
 
@@ -74,7 +76,7 @@ src/
    npm start
    ```
 
-El servidor se ejecutará en la entrada/salida estándar, haciéndolo compatible con Windsurf y otros clientes MCP.
+El servidor se ejecutará en la entrada/salida estándar, haciéndolo compatible con Claude Code y otros clientes MCP.
 
 ## Herramientas Disponibles
 
@@ -116,44 +118,89 @@ Recupera todos los comentarios de un ticket de Zendesk por su ID.
 
 - `ticket_id` (número, requerido): ID del ticket para obtener comentarios
 
-## Uso con Windsurf
+### 5. getTicketAttachments
 
-### Añadir a la Configuración `mcpServers` de Windsurf
+Lista todos los adjuntos de los comentarios de un ticket de Zendesk, incluyendo metadatos como nombre de archivo, URL, tipo MIME y tamaño.
 
-Añade la siguiente configuración a la sección `mcpServers` en el archivo de configuración de Windsurf:
+**Parámetros:**
 
-```json
-{
-  "mcpServers": {
-    "zendesk": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "tsx",
-        "/home/<nombre_usuario>/MCPservers/src/zendesk/src/index.ts"
-      ],
-      "env": {
-        "ZENDESK_SUBDOMAIN": "buk",
-        "ZENDESK_EMAIL": "email@buk.cl",
-        "ZENDESK_API_TOKEN": "token",
-        "DEFAULT_LOCALE": "es"
-      }
-    }
-  }
-}
+- `ticket_id` (número, requerido): ID del ticket del cual obtener los adjuntos
+
+**Respuesta:** Array de objetos `{ attachment, comment_id }` donde `attachment` contiene `id`, `file_name`, `content_url`, `content_type`, `size` e `inline`.
+
+### 6. readAttachment
+
+Descarga y retorna el contenido de un adjunto. Para imágenes, retorna un bloque de imagen que Claude puede interpretar directamente con sus capacidades de visión. Soporta imágenes, PDFs, HTML y archivos de texto. Rechaza archivos mayores a 10 MB.
+
+**Parámetros:**
+
+- `content_url` (string, requerido): URL del adjunto a descargar (obtenida de `getTicketAttachments`)
+- `content_type` (string, opcional): Tipo MIME del adjunto. Si se omite, se detecta automáticamente desde la respuesta HTTP.
+
+**Comportamiento según tipo MIME:**
+
+| Tipo | Comportamiento |
+|------|----------------|
+| `image/*` | Retorna bloque de imagen en base64 para interpretación visual |
+| `application/pdf` | Extrae y retorna el texto del PDF |
+| `text/html` | Limpia el HTML y retorna el texto |
+| `text/*` | Retorna el contenido como texto UTF-8 |
+| Otros | Retorna mensaje indicando tipo no soportado |
+
+## Uso con Claude Code
+
+### Registrar el MCP en Claude Code
+
+Ejecuta el siguiente comando reemplazando la ruta del proyecto, tu correo y tu API token:
+
+```bash
+claude mcp add zendesk --scope project node /home/tu-usuario/MCPservers/src/zendesk/dist/index.js \
+  -e ZENDESK_SUBDOMAIN=buk \
+  -e ZENDESK_EMAIL=tu-correo@buk.cl \
+  -e "ZENDESK_API_TOKEN=tu-token-api" \
+  -e DEFAULT_LOCALE=es
 ```
 
-Para obtener un API token de Zendesk, sigue los siguientes pasos:
+> **Nota:** el flag `--scope project` registra el MCP solo para el proyecto actual. Usa `--scope user` para registrarlo globalmente en tu usuario.
 
-> Nota:
-Para generar un token de API, debe ser un administrador y el acceso con token de API tiene que estar activado en su cuenta.
+El comando requiere que ya hayas clonado el repositorio y compilado el proyecto (`npm run build`) para que el archivo `dist/index.js` exista.
 
-### Generar un token de API
+### Pasos completos desde cero
 
-En el Centro de administración, haga clic en  Aplicaciones e integraciones en la barra lateral y luego seleccione API > API de Zendesk.
-Haga clic en el botón Agregar token de API a la derecha de Tokens de API activos. [Para más información puedes consultar la guia de zendesk](https://support.zendesk.com/hc/es/articles/4408889192858-Administración-del-acceso-a-la-API-de-Zendesk#topic_mmh_gm1_2yb)
+```bash
+# 1. Clonar el repositorio
+git clone https://github.com/bukhr/MCPservers.git
+cd MCPservers/src/zendesk
 
-Después de añadir esta configuración, podrás usar las herramientas de Zendesk dentro de Windsurf.
+# 2. Instalar dependencias y compilar
+npm install
+npm run build
+
+# 3. Registrar en Claude Code
+claude mcp add zendesk --scope project node /ruta/absoluta/MCPservers/src/zendesk/dist/index.js \
+  -e ZENDESK_SUBDOMAIN=buk \
+  -e ZENDESK_EMAIL=tu-correo@buk.cl \
+  -e "ZENDESK_API_TOKEN=tu-token-api" \
+  -e DEFAULT_LOCALE=es
+```
+
+### Generar un token de API de Zendesk
+
+> **Nota:** para generar un token de API debes ser administrador y el acceso con token de API debe estar activado en tu cuenta.
+
+En el Centro de administración, haz clic en **Aplicaciones e integraciones** en la barra lateral y selecciona **API > API de Zendesk**. Haz clic en **Agregar token de API** a la derecha de Tokens de API activos. [Más información en la guía de Zendesk](https://support.zendesk.com/hc/es/articles/4408889192858-Administración-del-acceso-a-la-API-de-Zendesk#topic_mmh_gm1_2yb)
+
+Después de registrar el MCP, **reinicia Claude Code** para que los cambios tomen efecto: sal con `exit` y vuelve a ingresar.
+
+### Verificar que el MCP quedó configurado
+
+Una vez dentro de Claude Code, ejecuta el comando:
+
+```text
+/mcp
+```
+
+Debiese aparecer `zendesk` en el listado de MCPs activos. Si no aparece, verifica que la ruta al archivo `dist/index.js` sea correcta y absoluta.
 
 ## Ejemplo de uso y caso de éxito
 
@@ -191,9 +238,7 @@ Solución recomendada: Mantener el truncamiento pero mejorar la forma en que se 
 - Utilizar acrónimos o abreviaturas consistentes para empresas con nombres largos
 Esta segunda opción sería compatible con Excel y proporcionaría una experiencia más profesional para el cliente.
 
-[https://windsurf.com/conversation-share/d46994a9-d0d6-45f2-9702-4c78d4d1f705](https://windsurf.com/conversation-share/d46994a9-d0d6-45f2-9702-4c78d4d1f705)
-
-### Nota: Gracias a este análisis identificamos el PR que habia cambiado el comportamiento por el cual se levanto el ticket
+### Nota: Gracias a este análisis identificamos el PR que había cambiado el comportamiento por el cual se levantó el ticket
 
 ## Desarrollo
 

--- a/src/zendesk/package.json
+++ b/src/zendesk/package.json
@@ -17,10 +17,12 @@
     "@modelcontextprotocol/sdk": "^1.9.0",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
+    "pdf-parse": "^1.1.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",
+    "@types/pdf-parse": "^1.1.4",
     "typescript": "^5.8.3"
   }
 }

--- a/src/zendesk/src/client.ts
+++ b/src/zendesk/src/client.ts
@@ -5,14 +5,15 @@ import * as readline from "node:readline";
 import { ZendeskConfig } from "./types/config.types.js";
 import { ArticleService } from "./services/article-service.js";
 import { TicketService } from "./services/ticket-service.js";
-import { 
-  ArticleSearchParams, 
-  ZendeskArticleResponse, 
-  ZendeskSearchResponse 
+import { AttachmentService, AttachmentWithCommentId, McpContentBlock } from "./services/attachment-service.js";
+import {
+  ArticleSearchParams,
+  ZendeskArticleResponse,
+  ZendeskSearchResponse
 } from "./types/article.types.js";
-import { 
-  ZendeskTicket, 
-  ZendeskTicketComment 
+import {
+  ZendeskTicket,
+  ZendeskTicketComment
 } from "./types/ticket.types.js";
 
 /**
@@ -22,6 +23,7 @@ import {
 export class ZendeskClient {
   private articleService: ArticleService;
   private ticketService: TicketService;
+  private attachmentService: AttachmentService;
   private defaultLocale: string;
   private config: ZendeskConfig;
 
@@ -32,10 +34,11 @@ export class ZendeskClient {
   constructor(config: ZendeskConfig) {
     this.config = config;
     this.defaultLocale = config.defaultLocale || "en";
-    
+
     // Initialize services
     this.articleService = new ArticleService(config);
     this.ticketService = new TicketService(config);
+    this.attachmentService = new AttachmentService(config);
   }
 
   /**
@@ -74,7 +77,24 @@ export class ZendeskClient {
     return this.ticketService.getTicketComments(ticketId);
   }
 
+  /**
+   * List all attachments from all comments of a ticket
+   * @param ticketId The ID of the ticket
+   * @returns Array of attachments with their parent comment ID
+   */
+  async getTicketAttachments(ticketId: number): Promise<AttachmentWithCommentId[]> {
+    return this.attachmentService.getTicketAttachments(ticketId);
+  }
 
+  /**
+   * Download and return the content of an attachment as MCP content blocks
+   * @param contentUrl The URL of the attachment
+   * @param contentType Optional MIME type hint
+   * @returns Array of MCP content blocks (text or image)
+   */
+  async readAttachment(contentUrl: string, contentType?: string): Promise<McpContentBlock[]> {
+    return this.attachmentService.readAttachment(contentUrl, contentType);
+  }
 
   /**
    * Run an interactive command-line interface for testing the client

--- a/src/zendesk/src/index.ts
+++ b/src/zendesk/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import { ZendeskClient } from "./client.js";
 import { registerArticleTools } from "./tools/article-tools.js";
 import { registerTicketTools } from "./tools/ticket-tools.js";
+import { registerAttachmentTools } from "./tools/attachment-tools.js";
 
 /**
  * Zendesk Help Center MCP Server
@@ -58,6 +59,7 @@ async function main() {
   // Register all tools
   registerArticleTools(server, zendeskClient, config.defaultLocale);
   registerTicketTools(server, zendeskClient);
+  registerAttachmentTools(server, zendeskClient);
 
   // Start the server
   const transport = new StdioServerTransport();

--- a/src/zendesk/src/services/article-service.ts
+++ b/src/zendesk/src/services/article-service.ts
@@ -1,10 +1,11 @@
 /**
  * Service for Zendesk Help Center articles
  */
+import { isAxiosError } from "axios";
 import { BaseService } from "./base-service.js";
-import { 
-  ZendeskArticle, 
-  ZendeskSearchResponse, 
+import {
+  ZendeskArticle,
+  ZendeskSearchResponse,
   ZendeskArticleResponse,
   ArticleSearchParams,
   ArticleGetParams
@@ -65,15 +66,39 @@ export class ArticleService extends BaseService {
   }
 
   /**
-   * Get detailed information about a specific article
+   * Fetch a single article from the Zendesk API using the locale in the URL path.
+   * The Zendesk Help Center API requires the locale as part of the path:
+   * /help_center/{locale}/articles/{id}.json
+   * @param id Article ID
+   * @param locale Locale code to use in the URL path
+   * @returns Raw article response
+   */
+  private async fetchArticle(id: number, locale: string): Promise<ZendeskArticleResponse> {
+    const articleUrl = `/help_center/${locale}/articles/${id}.json`;
+    return this.makeRequest<ZendeskArticleResponse>(articleUrl);
+  }
+
+  /**
+   * Get detailed information about a specific article.
+   * If the request fails with 404 and the locale is not 'es-419', retries automatically
+   * with 'es-419' (Latin American Spanish), which is the locale used by Buk articles.
    * @param params Parameters including article ID and locale
    * @returns Article data with cleaned HTML content
    */
   async getArticle(params: ArticleGetParams): Promise<ZendeskArticleResponse> {
     const { id, locale = this.defaultLocale } = params;
-    const articleUrl = `/help_center/articles/${id}.json`;
 
-    const data = await this.makeRequest<ZendeskArticleResponse>(articleUrl, { locale });
+    let data: ZendeskArticleResponse;
+    try {
+      data = await this.fetchArticle(id, locale);
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 404 && locale !== 'es-419') {
+        // Retry with es-419 (Latin American Spanish) — the locale used by Buk articles
+        data = await this.fetchArticle(id, 'es-419');
+      } else {
+        throw error;
+      }
+    }
 
     // Filter article to only include specified fields
     if (data.article) {

--- a/src/zendesk/src/services/attachment-service.ts
+++ b/src/zendesk/src/services/attachment-service.ts
@@ -1,0 +1,137 @@
+/**
+ * Service for downloading and processing Zendesk ticket attachments
+ */
+import { BaseService } from "./base-service.js";
+import { ZendeskAttachment, ZendeskTicketComment } from "../types/ticket.types.js";
+import { ZendeskConfig } from "../types/config.types.js";
+import { cleanHtmlContent } from "../utils/html-cleaner.js";
+
+const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10 MB
+
+export interface AttachmentWithCommentId {
+  attachment: ZendeskAttachment;
+  comment_id: number;
+}
+
+export type McpContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+/**
+ * Service class for downloading and processing Zendesk attachments
+ */
+export class AttachmentService extends BaseService {
+  /**
+   * Creates a new AttachmentService instance
+   * @param config Zendesk API configuration
+   */
+  constructor(config: ZendeskConfig) {
+    super(config);
+  }
+
+  /**
+   * List all attachments from all comments of a ticket
+   * @param ticketId The ID of the ticket
+   * @returns Array of attachments with their parent comment ID
+   */
+  async getTicketAttachments(ticketId: number): Promise<AttachmentWithCommentId[]> {
+    try {
+      const commentsUrl = `/tickets/${ticketId}/comments.json`;
+      const response = await this.makeRequest<{ comments: ZendeskTicketComment[] }>(commentsUrl);
+      const comments = response.comments;
+
+      const result: AttachmentWithCommentId[] = [];
+      for (const comment of comments) {
+        if (comment.attachments && comment.attachments.length > 0) {
+          for (const attachment of comment.attachments) {
+            result.push({ attachment, comment_id: comment.id });
+          }
+        }
+      }
+      return result;
+    } catch (error) {
+      console.error(`Failed to get attachments for ticket ${ticketId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Download and return the content of an attachment as MCP content blocks
+   * @param contentUrl The URL of the attachment
+   * @param contentType Optional MIME type hint (detected from response if not provided)
+   * @returns Array of MCP content blocks (text or image)
+   */
+  async readAttachment(contentUrl: string, contentType?: string): Promise<McpContentBlock[]> {
+    try {
+      const response = await this.httpClient.get(contentUrl, {
+        responseType: "arraybuffer",
+      });
+
+      const buffer = Buffer.from(response.data as ArrayBuffer);
+
+      if (buffer.length > MAX_ATTACHMENT_SIZE) {
+        return [
+          {
+            type: "text",
+            text: `El adjunto supera el tamaño máximo permitido de 10 MB (tamaño actual: ${(buffer.length / 1024 / 1024).toFixed(2)} MB).`,
+          },
+        ];
+      }
+
+      const mime = contentType || (response.headers["content-type"] as string) || "application/octet-stream";
+      // Normalize: strip parameters like charset
+      const mimeBase = mime.split(";")[0].trim().toLowerCase();
+
+      if (mimeBase.startsWith("image/")) {
+        return [
+          {
+            type: "image",
+            data: buffer.toString("base64"),
+            mimeType: mimeBase,
+          },
+        ];
+      }
+
+      if (mimeBase === "application/pdf") {
+        const pdfParse = (await import("pdf-parse")).default;
+        const pdfData = await pdfParse(buffer);
+        return [
+          {
+            type: "text",
+            text: pdfData.text,
+          },
+        ];
+      }
+
+      if (mimeBase === "text/html") {
+        const raw = buffer.toString("utf-8");
+        const cleaned = cleanHtmlContent(raw) ?? raw;
+        return [
+          {
+            type: "text",
+            text: cleaned,
+          },
+        ];
+      }
+
+      if (mimeBase.startsWith("text/")) {
+        return [
+          {
+            type: "text",
+            text: buffer.toString("utf-8"),
+          },
+        ];
+      }
+
+      return [
+        {
+          type: "text",
+          text: `Tipo de archivo no soportado para lectura: ${mimeBase}`,
+        },
+      ];
+    } catch (error) {
+      console.error(`Failed to read attachment at ${contentUrl}:`, error);
+      throw error;
+    }
+  }
+}

--- a/src/zendesk/src/services/ticket-service.ts
+++ b/src/zendesk/src/services/ticket-service.ts
@@ -5,6 +5,23 @@ import { BaseService } from "./base-service.js";
 import { ZendeskTicket, ZendeskTicketComment } from "../types/ticket.types.js";
 import { ZendeskConfig } from "../types/config.types.js";
 
+const TICKET_FIELDS: (keyof ZendeskTicket)[] = [
+  "id",
+  "url",
+  "subject",
+  "description",
+  "status",
+  "priority",
+  "type",
+  "created_at",
+  "updated_at",
+  "requester_id",
+  "assignee_id",
+  "organization_id",
+  "tags",
+  "custom_fields",
+];
+
 /**
  * Service class for Zendesk Support tickets
  */
@@ -18,15 +35,25 @@ export class TicketService extends BaseService {
   }
 
   /**
-   * Get detailed information about a specific Zendesk ticket
+   * Get detailed information about a specific Zendesk ticket.
+   * Filters the API response to only include relevant fields, avoiding the
+   * massive payload (~166K chars) that the raw Zendesk API returns.
    * @param ticketId The ID of the ticket to retrieve
-   * @returns Ticket data
+   * @returns Ticket data with only the relevant fields
    */
   async getTicket(ticketId: number): Promise<ZendeskTicket> {
     try {
       const ticketUrl = `/tickets/${ticketId}.json`;
-      const response = await this.makeRequest<{ ticket: ZendeskTicket }>(ticketUrl);
-      return response.ticket;
+      const response = await this.makeRequest<{ ticket: Record<string, unknown> }>(ticketUrl);
+      const raw = response.ticket;
+
+      const filtered = Object.fromEntries(
+        TICKET_FIELDS
+          .filter((field) => field in raw)
+          .map((field) => [field, raw[field]])
+      ) as unknown as ZendeskTicket;
+
+      return filtered;
     } catch (error) {
       console.error(`Failed to get ticket ${ticketId}:`, error);
       throw error;

--- a/src/zendesk/src/tools/attachment-tools.ts
+++ b/src/zendesk/src/tools/attachment-tools.ts
@@ -1,0 +1,72 @@
+/**
+ * MCP Tools for Zendesk ticket attachments
+ */
+import { ZendeskClient } from "../client.js";
+import { z } from "zod";
+
+/**
+ * Register attachment-related tools with the MCP server
+ * @param server MCP server instance
+ * @param zendeskClient Zendesk client instance
+ */
+export function registerAttachmentTools(server: any, zendeskClient: ZendeskClient) {
+  // Register ticket attachments listing tool
+  server.tool(
+    "getTicketAttachments",
+    "Lista todos los adjuntos de los comentarios de un ticket de Zendesk",
+    {
+      ticket_id: z.number().describe("El ID del ticket del cual obtener los adjuntos"),
+    },
+    async ({ ticket_id }: { ticket_id: number }) => {
+      try {
+        const data = await zendeskClient.getTicketAttachments(ticket_id);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(data, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error al obtener adjuntos del ticket: ${error}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // Register attachment download tool
+  server.tool(
+    "readAttachment",
+    "Descarga y retorna el contenido de un adjunto. Para imagenes retorna un bloque de imagen que Claude puede interpretar directamente.",
+    {
+      content_url: z.string().describe("La URL del adjunto a descargar"),
+      content_type: z.string().optional().describe("Tipo MIME del adjunto (opcional, se detecta automaticamente)"),
+    },
+    async ({ content_url, content_type }: { content_url: string; content_type?: string }) => {
+      try {
+        const blocks = await zendeskClient.readAttachment(content_url, content_type);
+
+        return {
+          content: blocks,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error al leer el adjunto: ${error}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/src/zendesk/src/types/ticket.types.ts
+++ b/src/zendesk/src/types/ticket.types.ts
@@ -2,17 +2,35 @@
  * Type definitions for Zendesk Support tickets
  */
 
+export interface ZendeskAttachment {
+  id: number;
+  file_name: string;
+  content_url: string;
+  content_type: string;
+  size: number;
+  inline: boolean;
+}
+
+export interface ZendeskTicketCustomField {
+  id: number;
+  value: string | null;
+}
+
 export interface ZendeskTicket {
   id: number;
+  url: string;
   subject: string;
   description: string;
   status: string;
-  priority: string;
+  priority: string | null;
+  type: string | null;
   created_at: string;
   updated_at: string;
   requester_id: number;
-  assignee_id: number;
-  organization_id: number;
+  assignee_id: number | null;
+  organization_id: number | null;
+  tags: string[];
+  custom_fields: ZendeskTicketCustomField[];
 }
 
 export interface ZendeskTicketComment {
@@ -22,6 +40,7 @@ export interface ZendeskTicketComment {
   html_body: string;
   public: boolean;
   created_at: string;
+  attachments?: ZendeskAttachment[];
 }
 
 


### PR DESCRIPTION
## Resumen de cambios para el PR                                                                                                                                                                             
         
                                                                                                                                                                                           
  Nuevas funcionalidades
                                                                                                                                                                                                            
  Soporte de adjuntos en tickets                                                                                                                                                                            
                                                      
  Se agregan 2 nuevas herramientas MCP:                                                                                                                                                                     
                                                                                                                                                                                                            
  - getTicketAttachments(ticket_id): lista todos los adjuntos de los comentarios de un ticket con sus metadatos (nombre, tipo MIME, tamaño, URL de descarga).                                               
  - readAttachment(content_url, content_type?): descarga y retorna el contenido del adjunto segun su tipo:
    - Imagenes (image/*): retorna un bloque de imagen en base64 que Claude puede interpretar directamente con vision.                                                                                       
    - PDFs: extrae el texto usando pdf-parse.                                                                                                                                                               
    - HTML: limpia el markup y retorna texto plano.                                                                                                                                                         
    - Texto plano: retorna el contenido como UTF-8.                                                                                                                                                         
    - Archivos mayores a 10MB son rechazados con mensaje de error.                                                                                                                                          
                                                                                                                                                                                                            
  ---
  
## Correcciones de bugs
              
  getArticle retornaba 404                            
                                                                                                                                                                                                            
  La URL se construia con el locale como query param en lugar de en el path. La API de Zendesk requiere /help_center/{locale}/articles/{id}.json. Ademas, se agrega fallback automatico a es-419 cuando el  
  locale configurado no encuentra el articulo, ya que los articulos de Buk estan en español latinoamericano.                                                                                                
                                                                                                                                                                                                            
  getTicket retornaba respuesta masiva (~166K caracteres)                                                                                                                                                   
                                                      
  La respuesta raw de Zendesk incluia decenas de campos innecesarios. Se aplica un filtrado a los campos relevantes: id, url, subject, description, status, priority, type, tags, custom_fields, created_at,
   updated_at, requester_id, assignee_id, organization_id.
                                                                                                                                                                                                            
  ---
## Documentacion                                       
               
  Se reemplaza la seccion de instalacion con Windsurf por instrucciones para Claude Code usando claude mcp add, incluyendo pasos desde el git clone, el comando de registro con variables de entorno,
  instrucciones para reiniciar Claude y verificacion con /mcp.   